### PR TITLE
Pid minter

### DIFF
--- a/src/main/java/org/fcrepo/ffmodeshapeprototype/AbstractResource.java
+++ b/src/main/java/org/fcrepo/ffmodeshapeprototype/AbstractResource.java
@@ -16,6 +16,8 @@ import javax.jcr.Workspace;
 import javax.ws.rs.core.Response;
 
 import org.codehaus.jackson.map.ObjectMapper;
+import org.fcrepo.ffmodeshapeprototype.identifiers.PidMinter;
+import org.fcrepo.ffmodeshapeprototype.identifiers.UUIDPidMinter;
 import org.infinispan.schematic.document.ParsingException;
 import org.modeshape.common.SystemFailureException;
 import org.modeshape.common.collection.Problems;
@@ -41,6 +43,8 @@ public abstract class AbstractResource {
 
 	static protected Configuration freemarker = null;
 	static protected Workspace ws = null;
+	
+	protected static PidMinter pidMinter = new UUIDPidMinter();;
 
 	public AbstractResource() throws ConfigurationException,
 			RepositoryException, IOException {
@@ -125,7 +129,5 @@ public abstract class AbstractResource {
 		return in;
 	}
 
-    protected String mintPid() {
-    		return java.util.UUID.randomUUID().toString();
-    }
+
 }

--- a/src/main/java/org/fcrepo/ffmodeshapeprototype/AbstractResource.java
+++ b/src/main/java/org/fcrepo/ffmodeshapeprototype/AbstractResource.java
@@ -39,7 +39,6 @@ public abstract class AbstractResource {
 
 	private final Logger logger = Logger.getLogger(AbstractResource.class);
 
-    static protected int pid_index = 0;
 	static protected Configuration freemarker = null;
 	static protected Workspace ws = null;
 
@@ -127,7 +126,6 @@ public abstract class AbstractResource {
 	}
 
     protected String mintPid() {
-        pid_index += 1;
-        return "assigned_pid_" + pid_index;
+    		return java.util.UUID.randomUUID().toString();
     }
 }

--- a/src/main/java/org/fcrepo/ffmodeshapeprototype/FedoraIdentifiers.java
+++ b/src/main/java/org/fcrepo/ffmodeshapeprototype/FedoraIdentifiers.java
@@ -1,0 +1,45 @@
+package org.fcrepo.ffmodeshapeprototype;
+
+import java.io.IOException;
+
+import javax.jcr.RepositoryException;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.Response;
+
+import org.modeshape.jcr.ConfigurationException;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSet.Builder;
+
+import freemarker.template.TemplateException;
+
+@Path("/")
+public class FedoraIdentifiers extends AbstractResource {
+
+	public FedoraIdentifiers() throws ConfigurationException,
+			RepositoryException, IOException {
+		super();
+	}
+
+    @POST
+    @Path("/nextPID")
+    @Produces("text/xml")
+    public Response getNextPid(@QueryParam("numPids") @DefaultValue("1") Integer numPids) throws RepositoryException,
+            IOException, TemplateException {
+
+        ImmutableSet.Builder<String> b = new Builder<String>();
+        for(int i = 0; i < numPids; i++) {
+            b.add(mintPid());
+        }
+        return Response
+                .ok()
+                .entity(renderTemplate("nextPid.ftl",
+                        ImmutableMap.of("pids", (Object) b.build())))
+                .build();
+    }
+}

--- a/src/main/java/org/fcrepo/ffmodeshapeprototype/FedoraIdentifiers.java
+++ b/src/main/java/org/fcrepo/ffmodeshapeprototype/FedoraIdentifiers.java
@@ -26,20 +26,20 @@ public class FedoraIdentifiers extends AbstractResource {
 		super();
 	}
 
-    @POST
-    @Path("/nextPID")
-    @Produces("text/xml")
-    public Response getNextPid(@QueryParam("numPids") @DefaultValue("1") Integer numPids) throws RepositoryException,
-            IOException, TemplateException {
+	@POST
+	@Path("/nextPID")
+	@Produces("text/xml")
+	public Response getNextPid(
+			@QueryParam("numPids") @DefaultValue("1") Integer numPids)
+			throws RepositoryException, IOException, TemplateException {
 
-        ImmutableSet.Builder<String> b = new Builder<String>();
-        for(int i = 0; i < numPids; i++) {
-            b.add(mintPid());
-        }
-        return Response
-                .ok()
-                .entity(renderTemplate("nextPid.ftl",
-                        ImmutableMap.of("pids", (Object) b.build())))
-                .build();
-    }
+		ImmutableSet.Builder<String> b = new Builder<String>();
+		for (int i = 0; i < numPids; i++) {
+			b.add(pidMinter.mintPid());
+		}
+		return Response
+				.ok()
+				.entity(renderTemplate("nextPid.ftl",
+						ImmutableMap.of("pids", (Object) b.build()))).build();
+	}
 }

--- a/src/main/java/org/fcrepo/ffmodeshapeprototype/FedoraObjects.java
+++ b/src/main/java/org/fcrepo/ffmodeshapeprototype/FedoraObjects.java
@@ -32,14 +32,12 @@ public class FedoraObjects extends AbstractResource {
 			IOException {
 		super();
 	}
-    @POST
-    @Path("/new")
-    public Response ingestAndMint()
-            throws RepositoryException {
-        final String pid = mintPid();
 
-        return ingest(pid);
-    }
+	@POST
+	@Path("/new")
+	public Response ingestAndMint() throws RepositoryException {
+		return ingest(pidMinter.mintPid());
+	}
 
 	@POST
 	@Path("/{pid}")
@@ -51,9 +49,9 @@ public class FedoraObjects extends AbstractResource {
 		if (session.hasPermission("/" + pid, "add_node")) {
 			final Node obj = root.addNode(pid, "fedora:object");
 			obj.addMixin("fedora:owned");
-            obj.addMixin("fedora:created");
+			obj.addMixin("fedora:created");
 			obj.setProperty("fedora:ownerId", "Fedo Radmin");
-            obj.setProperty("jcr:lastModified", Calendar.getInstance());
+			obj.setProperty("jcr:lastModified", Calendar.getInstance());
 			session.save();
 			return Response.status(Response.Status.CREATED).entity(pid).build();
 		} else {
@@ -86,8 +84,5 @@ public class FedoraObjects extends AbstractResource {
 			throws RepositoryException {
 		return deleteResource(pid);
 	}
-        
-        
-
 
 }

--- a/src/main/java/org/fcrepo/ffmodeshapeprototype/FedoraObjects.java
+++ b/src/main/java/org/fcrepo/ffmodeshapeprototype/FedoraObjects.java
@@ -88,21 +88,6 @@ public class FedoraObjects extends AbstractResource {
 	}
         
         
-    @POST
-    @Path("/nextPID")
-    @Produces("text/xml")
-    public Response getNextPid(@QueryParam("numPids") @DefaultValue("1") String numPids) throws RepositoryException,
-            IOException, TemplateException {
 
-        ImmutableSet.Builder<String> b = new ImmutableSet.Builder<String>();
-        for(int i = 0; i < Integer.parseInt(numPids); i++) {
-            b.add(mintPid());
-        }
-        return Response
-                .ok()
-                .entity(renderTemplate("nextPid.ftl",
-                        ImmutableMap.of("pids", (Object) b.build())))
-                .build();
-    }
 
 }

--- a/src/main/java/org/fcrepo/ffmodeshapeprototype/identifiers/PidMinter.java
+++ b/src/main/java/org/fcrepo/ffmodeshapeprototype/identifiers/PidMinter.java
@@ -1,0 +1,7 @@
+package org.fcrepo.ffmodeshapeprototype.identifiers;
+
+public interface PidMinter {
+	
+    public String mintPid() ;
+		
+}

--- a/src/main/java/org/fcrepo/ffmodeshapeprototype/identifiers/UUIDPidMinter.java
+++ b/src/main/java/org/fcrepo/ffmodeshapeprototype/identifiers/UUIDPidMinter.java
@@ -1,0 +1,10 @@
+package org.fcrepo.ffmodeshapeprototype.identifiers;
+
+public class UUIDPidMinter implements PidMinter {
+
+	@Override
+	public String mintPid() {
+		return java.util.UUID.randomUUID().toString();
+	}
+
+}

--- a/src/test/java/org/fcrepo/ffmodeshapeprototype/FedoraIdentifiersTest.java
+++ b/src/test/java/org/fcrepo/ffmodeshapeprototype/FedoraIdentifiersTest.java
@@ -1,0 +1,49 @@
+package org.fcrepo.ffmodeshapeprototype;
+
+import static junit.framework.Assert.assertEquals;
+
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.httpclient.HttpClient;
+import org.apache.commons.httpclient.methods.PostMethod;
+import org.jboss.resteasy.plugins.server.tjws.TJWSEmbeddedJaxrsServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Created with IntelliJ IDEA. User: cabeer Date: 1/17/13 Time: 14:11 To change
+ * this template use File | Settings | File Templates.
+ */
+public class FedoraIdentifiersTest {
+
+	private TJWSEmbeddedJaxrsServer server;
+	int SERVER_PORT = 9999;
+
+	@Before
+	public void start() {
+
+		server = new TJWSEmbeddedJaxrsServer();
+		server.setPort(SERVER_PORT);
+		server.getDeployment().getActualResourceClasses()
+				.add(FedoraIdentifiers.class);
+		server.start();
+	}
+
+	@After
+	public void stop() {
+		server.stop();
+	}
+
+	@Test
+	public void testGetNextPid() throws Exception {
+		HttpClient client = new HttpClient();
+		PostMethod method = new PostMethod("http://localhost:" + SERVER_PORT
+				+ "/nextPID");
+		method.addRequestHeader("Accepts", "text/xml");
+		int status = client.executeMethod(method);
+		System.out.println("Executed testGetNextPid()");
+		System.out.println(method.getResponseBodyAsString());
+		assertEquals(HttpServletResponse.SC_OK, status);
+	}
+}

--- a/src/test/java/org/fcrepo/ffmodeshapeprototype/FedoraObjectsTest.java
+++ b/src/test/java/org/fcrepo/ffmodeshapeprototype/FedoraObjectsTest.java
@@ -67,11 +67,4 @@ public class FedoraObjectsTest {
         assertEquals(204, status);
     }
 
-    @Test
-    public void testGetNextPid() throws Exception {
-        HttpClient client = new HttpClient();
-        PostMethod method = new PostMethod("http://localhost:" + SERVER_PORT + "/objects/nextPID");
-        int status = client.executeMethod(method);
-        assertEquals(200, status);
-    }
 }

--- a/src/test/resources/log4j.properties
+++ b/src/test/resources/log4j.properties
@@ -1,0 +1,13 @@
+
+# This is not needed by Jetty - but it helps with many web apps.
+
+log4j.rootLogger=INFO, stdout
+
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%-4r [%t] %-5p %c %x - %m%n
+
+# Set up the default logging to be INFO level, then override specific units
+log4j.logger.org.infinispan=DEBUG
+log4j.logger.org.modeshape=DEBUG
+log4j.logger.org.fcrepo=DEBUG


### PR DESCRIPTION
Added interface and default UUID-based implementation for pid minting. Also separated nextPID endpoint into a new FedoraIdentifiers resource class, on the assumption that we may want more than one kind of identifier and we may want more than one service (more than minting).
